### PR TITLE
Updated int size to uint32_t on arduino led example.  This fixed samp…

### DIFF
--- a/example/Arduino/led/led.ino
+++ b/example/Arduino/led/led.ino
@@ -111,7 +111,8 @@ void setup()
 
 void loop()
 {
-    static int j, color;
+    static int j;
+    static uint32_t color;
     j++;
     for (int i = 0; i < APA102_QUANTITY; i++)
     {


### PR DESCRIPTION
The sample Arduino led program was not showing red colors.  Tracked this down to a difference from the keil version of the same example which used UINT32 color;